### PR TITLE
ci: add safe deployment with pre-verification with separated build and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master, develop ]
     tags:
       - v*
-  pull_request:
-    branches: [ master ]
 
 permissions:
   contents: read
@@ -23,13 +21,12 @@ jobs:
   build-staging:
     name: Build for Staging (x86)
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v4
 
       - name: Create GitHub Deployment
         id: deployment
-        if: github.event_name == 'push'
         uses: actions/github-script@v7
         with:
           script: |
@@ -62,7 +59,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,prefix=
 
       - name: Build and push Docker image
@@ -77,7 +73,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deployment Status Success
-        if: success() && github.event_name == 'push'
+        if: success()
         uses: actions/github-script@v7
         with:
           script: |
@@ -90,7 +86,7 @@ jobs:
             })
 
       - name: Deployment Status Failure
-        if: failure() && github.event_name == 'push'
+        if: failure()
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,15 +102,43 @@ jobs:
               log_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             })
 
-  # master 브랜치: self-hosted (ARM) → Oracle Cloud
-  build-and-deploy-production:
-    name: Build and Deploy Production (ARM)
+  # master 브랜치: 이미지 빌드 & 푸시만 (배포 X)
+  build-production:
+    name: Build Production Image (ARM)
     runs-on: self-hosted
-    environment: 'oracle-cloud-solicare-instance'
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
 
+      - name: Log in to Container Registry
+        shell: bash
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set lowercase image name
+        shell: bash
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Build Docker image
+        shell: bash
+        run: |
+          docker build -t ghcr.io/${{ env.IMAGE_NAME_LC }}:latest \
+                       -t ghcr.io/${{ env.IMAGE_NAME_LC }}:master \
+                       -t ghcr.io/${{ env.IMAGE_NAME_LC }}:${{ github.sha }} .
+
+      - name: Push Docker image
+        shell: bash
+        run: |
+          docker push ghcr.io/${{ env.IMAGE_NAME_LC }}:latest
+          docker push ghcr.io/${{ env.IMAGE_NAME_LC }}:master
+          docker push ghcr.io/${{ env.IMAGE_NAME_LC }}:${{ github.sha }}
+
+  # v* 태그: Oracle Cloud 배포
+  deploy-production:
+    name: Deploy to Production (ARM)
+    runs-on: self-hosted
+    environment: 'oracle-cloud-solicare-instance'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
       - name: Create GitHub Deployment
         id: deployment
         uses: actions/github-script@v7
@@ -132,29 +160,57 @@ jobs:
         shell: bash
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build Docker image
+      - name: Set lowercase image name
         shell: bash
-        run: |
-          docker build -t ghcr.io/${{ github.repository }}:latest \
-                       -t ghcr.io/${{ github.repository }}:master \
-                       -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
-      - name: Push Docker image
+      - name: Pull latest image
         shell: bash
-        run: |
-          docker push ghcr.io/${{ github.repository }}:latest
-          docker push ghcr.io/${{ github.repository }}:master
-          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+        run: docker pull ghcr.io/${{ env.IMAGE_NAME_LC }}:latest
 
-      - name: Stop and remove existing container
+      # 새 컨테이너를 테스트 포트에서 먼저 검증
+      - name: Start new container for verification
         shell: bash
         run: |
+          docker run -d \
+            --name solicare-backend-new \
+            -p 8081:8080 \
+            -e JWT_SECRET='${{ secrets.JWT_SECRET }}' \
+            -e DB_URL='${{ secrets.DB_URL }}' \
+            -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
+            -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
+            -e FIREBASE_ADMIN_JSON_BASE64='${{ secrets.FIREBASE_ADMIN_JSON_BASE64 }}' \
+            -e SPRINGDOC_SERVER_URL='${{ vars.SERVER_URL }}' \
+            ghcr.io/${{ env.IMAGE_NAME_LC }}:latest
+
+      - name: Verify new container health
+        shell: bash
+        run: |
+          for i in {1..15}; do
+            if curl -sSf http://localhost:8081/actuator/health > /dev/null; then
+              echo "[SUCCESS] New container is healthy."
+              exit 0
+            fi
+            echo "Waiting for health check... ($i/15)"
+            sleep 4
+          done
+          echo "[ERROR] New container health check failed. Rolling back..."
+          docker logs solicare-backend-new
+          docker rm -f solicare-backend-new
+          exit 1
+
+      # 검증 성공 시 기존 컨테이너 교체
+      - name: Switch to new container
+        shell: bash
+        run: |
+          # 기존 컨테이너 제거
           docker stop solicare-backend || true
           docker rm solicare-backend || true
 
-      - name: Run new container
-        shell: bash
-        run: |
+          # 테스트 컨테이너 제거 (검증용이었으므로)
+          docker rm -f solicare-backend-new
+
+          # 실제 포트로 새 컨테이너 실행
           docker run -d \
             --name solicare-backend \
             --restart unless-stopped \
@@ -165,22 +221,9 @@ jobs:
             -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
             -e FIREBASE_ADMIN_JSON_BASE64='${{ secrets.FIREBASE_ADMIN_JSON_BASE64 }}' \
             -e SPRINGDOC_SERVER_URL='${{ vars.SERVER_URL }}' \
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ env.IMAGE_NAME_LC }}:latest
 
-      - name: Health Check
-        shell: bash
-        run: |
-          for i in {1..15}; do
-            if curl -sSf http://localhost:8080/actuator/health > /dev/null; then
-              echo "[SUCCESS] Container deployed successfully."
-              exit 0
-            fi
-            echo "Waiting for health check... ($i/15)"
-            sleep 4
-          done
-          echo "[ERROR] Health check failed."
-          docker logs solicare-backend
-          exit 1
+          echo "[SUCCESS] Container switched successfully."
 
       - name: Deployment Status Success
         if: success()


### PR DESCRIPTION

- Fix lowercase image name for Docker registry
- Split master push (build only) and v* tag (deploy only)
- Add container health verification before switching
- Rollback automatically if new container fails health check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Separated image building from production deployments: builds now run independently, deployments are tag-triggered (v-prefixed tags).
  * Staging pipeline now runs only on develop branch pushes.
  * Builds now produce and push multi-tag container images to the registry.
  * Deployments perform a staged verification using a test container and health check (on a verification port) before switching to the live container.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->